### PR TITLE
Fix signature processing

### DIFF
--- a/lib/Coincheck/CoincheckPayment.php
+++ b/lib/Coincheck/CoincheckPayment.php
@@ -49,11 +49,11 @@ class CoincheckPayment
         throw new \Exception($key . ' is not able to override');
     }
 
-    public function setSignature($path, $arr = array())
+    public function setSignature($path, $body)
     {
         $nonce = time();
         $url = $this->apiBase.$path;
-        $message = $nonce.$url.http_build_query($arr);
+        $message = $nonce.$url.$body;
         $signature = hash_hmac("sha256", $message, $this->secretKey);
         $this->client->setDefaultOption('headers/ACCESS-NONCE', $nonce);
         $this->client->setDefaultOption('headers/ACCESS-SIGNATURE', $signature);
@@ -68,7 +68,7 @@ class CoincheckPayment
      */
     public function request($method, $path, $paramData)
     {
-        $this->setSignature($path, $paramData);
+        $this->setSignature($path, json_encode($paramData));
         $req = $this->client->createRequest($method, $path, array());
         if($method == 'post' || $method == 'delete') {
             $req->setBody(json_encode($paramData),'application/json');


### PR DESCRIPTION
There are some issue on signature generation logic in this code.

The original code uses `http_build_query()` to build a signature message but it passes a JSON data to the server, which caused a conflict between the requests and the signatures and failed to authenticate the request.
I have fixed this issue by using JSON data as a signature message.
I also have tested using my account and confirmed that my code is now fully working.
